### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Installation methods
 - Download DMG from [Official website](https://lunar.fyi)
 - Download DMG from the [Releases page](https://github.com/alin23/Lunar/releases)
-- `brew cask install lunar`
+- `brew install --cask lunar`
 
 ![Display page](Images/display.png)
 ![Settings page](Images/settings.png)


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot: 
![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103143622-6069a900-475d-11eb-9f4c-a70ac6cb667c.png)
