### PR TITLE
fix: bump platformio/espressif to 5.3.0 to maintain darwin_arm64 compatibility

### DIFF
--- a/Lunar/ALS/install.sh
+++ b/Lunar/ALS/install.sh
@@ -12,12 +12,12 @@ LOG_PATH=${LOG_PATH:-/tmp/lunar-sensor-install.log}
 BOARD="${BOARD:-esp32dev}"
 
 if [[ "$BOARD" == "sparkfun_esp32s2_thing_plus" ]]; then
-    PLATFORM_VERSION="${PLATFORM_VERSION:-platformio/espressif32@5.1.0}"
+    PLATFORM_VERSION="${PLATFORM_VERSION:-platformio/espressif32@5.3.0}"
     PLATFORM="${PLATFORM:-ESP32}"
     SDA="${SDA:-01}"
     SCL="${SCL:-02}"
 elif [[ "$BOARD" == "adafruit_metro_esp32s2" || "$BOARD" == "adafruit_funhouse_esp32s2"  || "$BOARD" == "adafruit_feather_esp32s2_tft"  || "$BOARD" == "adafruit_magtag29_esp32s2" ]]; then
-    PLATFORM_VERSION="${PLATFORM_VERSION:-platformio/espressif32@5.1.0}"
+    PLATFORM_VERSION="${PLATFORM_VERSION:-platformio/espressif32@5.3.0}"
     PLATFORM="${PLATFORM:-ESP32}"
     SDA="${SDA:-33}"
     SCL="${SCL:-34}"
@@ -27,7 +27,7 @@ elif [[ "$BOARD" == "nodemcuv2" || "$BOARD" == "d1_mini" || "$BOARD" == "d1_mini
     SDA="${SDA:-D2}"
     SCL="${SCL:-D1}"
 elif [[ "$BOARD" == "esp32dev" || "$BOARD" == "lolin32" || "$BOARD" == "lolin32_lite" || "$BOARD" == "nodemcu-32s" ]]; then
-    PLATFORM_VERSION="${PLATFORM_VERSION:-platformio/espressif32@5.1.0}"
+    PLATFORM_VERSION="${PLATFORM_VERSION:-platformio/espressif32@5.3.0}"
     PLATFORM="${PLATFORM:-ESP32}"
     SDA="${SDA:-19}"
     SCL="${SCL:-23}"


### PR DESCRIPTION
Lately, when trying to install the Lunar light sensor package on an ESP32 board off an M1 Pro Macbook, this pops up:

```
Processing lunarsensor (board: adafruit_metro_esp32s2; framework: arduino; platform: platformio/espressif32@5.1.0)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Tool Manager: Installing espressif/toolchain-riscv32-esp @ 8.4.0+2021r2-patch3
INFO Installing espressif/toolchain-riscv32-esp @ 8.4.0+2021r2-patch3
Error: Could not find the package with 'espressif/toolchain-riscv32-esp @ 8.4.0+2021r2-patch3' requirements for your system 'darwin_arm64'
```


Checking `espressif/toolchain-riscv32-esp`'s [version info](https://registry.platformio.org/tools/espressif/toolchain-riscv32-esp/versions) on PlatformIO, the only `8.x` package still published is `8.4.0+2021r2-patch5`

Digging further into the dependency chain, it seems that `platformio/espressif32@5.3.0` uses the latest `espressif/toolchain-riscv32-esp` version, which enables using an Apple Silicon device to provision a board using ESPHome.


Not sure about other ESP32 boards, although being a minor version update, I'd hope everything remains stable.