### PR TITLE
Add CLI install location to succcessful print statement

### DIFF
--- a/Lunar/AppDelegate.swift
+++ b/Lunar/AppDelegate.swift
@@ -2136,7 +2136,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, CLLocationManagerDeleg
 
         do {
             try installCLIBinary()
-            print("Lunar CLI installed")
+            print("Lunar CLI installed at \(CLI_BIN_DIR)")
         } catch let error as InstallCLIError {
             print(error.message)
             print(error.info)


### PR DESCRIPTION
Installing the lunar CLI via the terminal can lead to the install "silently failing" or seeming to fail if `~/.local/bin` is not in your `$PATH`.

This simply adds the install location to the success print message so that the user knows where the CLI was installed and can add the necessary directory to their `$PATH` if required.

Full disclosure: I did not build/test this at all, I am just borrowing the `CLI_BIN_DIR` variable that is already used and printing it out for the user to see.